### PR TITLE
Static Loc-I datatypes as json

### DIFF
--- a/json-ld/loci-types.json
+++ b/json-ld/loci-types.json
@@ -1,0 +1,204 @@
+[
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2016",
+        "title": "MeshBlock",
+        "uri": "http://linked.data.gov.au/def/asgs#MeshBlock",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2016/meshblock/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel1",
+            "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel2",
+            "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3",
+            "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4",
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
+        ],
+        "baseType": true
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2016",
+        "title": "SA1",
+        "uri": "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel1",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2016/statisticalarealevel1/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel2",
+            "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3",
+            "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4",
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2016",
+        "title": "SA2",
+        "uri": "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel2",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2016/statisticalarealevel2/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3",
+            "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4",
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2016",
+        "title": "SA3",
+        "uri": "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2016/statisticalarealevel3/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4",
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2016",
+        "title": "SA4",
+        "uri": "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2016/statisticalarealevel4/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2016",
+        "title": "StateOrTerritory",
+        "uri": "http://linked.data.gov.au/def/asgs#StateOrTerritory",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2016/stateorterritory/"
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
+        "title": "MeshBlock",
+        "uri": "http://linked.data.gov.au/def/asgs#MeshBlock",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2011/meshblock/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel1",
+            "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel2",
+            "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3",
+            "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4",
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
+        ],
+        "baseType": true
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
+        "title": "SA1",
+        "uri": "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel1",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2011/statisticalarealevel1/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel2",
+            "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3",
+            "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4",
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
+        "title": "SA2",
+        "uri": "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel2",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2011/statisticalarealevel2/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3",
+            "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4",
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
+        "title": "SA3",
+        "uri": "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2011/statisticalarealevel3/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4",
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
+        "title": "SA4",
+        "uri": "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2011/statisticalarealevel4/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
+        "title": "StateOrTerritory",
+        "uri": "http://linked.data.gov.au/def/asgs#StateOrTerritory",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2011/stateorterritory/"
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/geofabric",
+        "title": "Contracted Catchment",
+        "uri": "http://linked.data.gov.au/def/geofabric#ContractedCatchment",
+        "prefix": "http://linked.data.gov.au/dataset/geofabric/contractedcatchment/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/geofabric#RiverRegion",
+            "http://linked.data.gov.au/def/geofabric#DrainageDivision"
+        ],
+        "baseType": true
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/geofabric",
+        "title": "River Region",
+        "uri": "http://linked.data.gov.au/def/geofabric#RiverRegion",
+        "prefix": "http://linked.data.gov.au/dataset/geofabric/riverregion/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/geofabric#DrainageDivision"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/geofabric",
+        "title": "Drainage Division",
+        "uri": "http://linked.data.gov.au/def/geofabric#DrainageDivision",
+        "prefix": "http://linked.data.gov.au/dataset/geofabric/drainagedivision/"
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/gnaf",
+        "title": "Address",
+        "uri": "http://linked.data.gov.au/def/gnaf#Address",
+        "prefix": "http://linked.data.gov.au/dataset/gnaf/address/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/gnaf#StreetLocality",
+            "http://linked.data.gov.au/def/gnaf#Locality"
+        ],
+        "baseType": true
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/gnaf",
+        "title": "Street Locality",
+        "uri": "http://linked.data.gov.au/def/gnaf#StreetLocality",
+        "prefix": "http://linked.data.gov.au/dataset/gnaf/streetLocality/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/gnaf#Locality"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/gnaf",
+        "title": "Locality",
+        "uri": "http://linked.data.gov.au/def/gnaf#Locality",
+        "prefix": "http://linked.data.gov.au/dataset/gnaf/locality/"
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/gnaf-2016-05",
+        "title": "Address",
+        "uri": "http://linked.data.gov.au/def/gnaf#Address",
+        "prefix": "http://linked.data.gov.au/dataset/gnaf-2016-05/address/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/gnaf#StreetLocality",
+            "http://linked.data.gov.au/def/gnaf#Locality"
+        ],
+        "baseType": true
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/gnaf-2016-05",
+        "title": "Street Locality",
+        "uri": "http://linked.data.gov.au/def/gnaf#StreetLocality",
+        "prefix": "http://linked.data.gov.au/dataset/gnaf-2016-05/streetLocality/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/gnaf#Locality"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/gnaf-2016-05",
+        "title": "Locality",
+        "uri": "http://linked.data.gov.au/def/gnaf#Locality",
+        "prefix": "http://linked.data.gov.au/dataset/gnaf-2016-05/locality/"
+    }
+]

--- a/json-ld/loci-types.json
+++ b/json-ld/loci-types.json
@@ -175,7 +175,38 @@
             "http://linked.data.gov.au/def/asgs#StateOrTerritory"
         ]
     },
-
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2016",
+        "title": "Local Government Area",
+        "uri": "http://linked.data.gov.au/def/asgs#LocalGovernmentArea",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2016/localgovernmentarea/",
+        "withinTypes": [
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2016",
+        "title": "Commonwealth Electoral Division",
+        "uri": "http://linked.data.gov.au/def/asgs#CommonwealthElectoralDivision",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2016/commonwealthelectoraldivision/",
+        "withinTypes": [
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2016",
+        "title": "State Suburb",
+        "uri": "http://linked.data.gov.au/def/asgs#StateSuburb",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2016/statesuburb/",
+        "withinTypes": [
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2016",
+        "title": "Natural Resource Management Region",
+        "uri": "http://linked.data.gov.au/def/asgs#NaturalResourceManagementRegion",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2016/naturalresourcemanagementregion/",
+        "withinTypes": [
+        ]
+    },
     {
         "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
         "title": "MeshBlock",
@@ -238,93 +269,6 @@
         "uri": "http://linked.data.gov.au/def/asgs#StateOrTerritory",
         "prefix": "http://linked.data.gov.au/dataset/asgs2011/stateorterritory/"
     },
-    {
-        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
-        "title": "Greater Capital City Statistical Area",
-        "uri": "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3",
-        "prefix": "http://linked.data.gov.au/dataset/asgs2011/greatercapitalcitystatisticalarea/",
-        "withinTypes": [
-            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
-        ]
-    },
-    {
-        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
-        "title": "Significant Urban Area",
-        "uri": "http://linked.data.gov.au/def/asgs#SignificantUrbanArea",
-        "prefix": "http://linked.data.gov.au/dataset/asgs2011/significanturbanarea/",
-        "withinTypes": [
-        ]
-    },
-    {
-        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
-        "title": "Remoteness Area",
-        "uri": "http://linked.data.gov.au/def/asgs#RemotenessArea",
-        "prefix": "http://linked.data.gov.au/dataset/asgs2011/remotenessarea/",
-        "withinTypes": [
-            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
-        ]
-    },
-    {
-        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
-        "title": "Indigenous Location",
-        "uri": "http://linked.data.gov.au/def/asgs#IndigenousLocation",
-        "prefix": "http://linked.data.gov.au/dataset/asgs2011/indigenouslocation/",
-        "withinTypes": [
-            "http://linked.data.gov.au/def/asgs#StateOrTerritory",
-            "http://linked.data.gov.au/def/asgs#IndigenousArea",
-            "http://linked.data.gov.au/def/asgs#IndigenousRegion"
-        ]
-    },
-    {
-        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
-        "title": "Indigenous Area",
-        "uri": "http://linked.data.gov.au/def/asgs#IndigenousArea",
-        "prefix": "http://linked.data.gov.au/dataset/asgs2011/indigenousarea/",
-        "withinTypes": [
-            "http://linked.data.gov.au/def/asgs#StateOrTerritory",
-            "http://linked.data.gov.au/def/asgs#IndigenousRegion"
-        ]
-    },
-    {
-        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
-        "title": "Indigenous Region",
-        "uri": "http://linked.data.gov.au/def/asgs#IndigenousRegion",
-        "prefix": "http://linked.data.gov.au/dataset/asgs2011/indigenousregion/",
-        "withinTypes": [
-            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
-        ]
-    },
-    {
-        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
-        "title": "Urban Centre and Locality",
-        "uri": "http://linked.data.gov.au/def/asgs#UrbanCentreAndLocality",
-        "prefix": "http://linked.data.gov.au/dataset/asgs2011/urbancentreandlocality",
-        "withinTypes": [
-            "http://linked.data.gov.au/def/asgs#StateOrTerritory",
-            "http://linked.data.gov.au/def/asgs#SectionOfStateRange",
-            "http://linked.data.gov.au/def/asgs#SectionOfState"
-        ]
-    },
-    {
-        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
-        "title": "Section of State Range",
-        "uri": "http://linked.data.gov.au/def/asgs#SectionOfStateRange",
-        "prefix": "http://linked.data.gov.au/dataset/asgs2011/sectionofstaterange/",
-        "withinTypes": [
-            "http://linked.data.gov.au/def/asgs#StateOrTerritory",
-            "http://linked.data.gov.au/def/asgs#SectionOfState"
-        ]
-    },
-    {
-        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
-        "title": "Section of State",
-        "uri": "http://linked.data.gov.au/def/asgs#SectionOfState",
-        "prefix": "http://linked.data.gov.au/dataset/asgs2011/sectionofstate/",
-        "withinTypes": [
-            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
-        ]
-    },    
-    
     {
         "datasetUri": "http://linked.data.gov.au/dataset/geofabric",
         "title": "Contracted Catchment",

--- a/json-ld/loci-types.json
+++ b/json-ld/loci-types.json
@@ -9,7 +9,20 @@
             "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel2",
             "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3",
             "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4",
-            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory",
+            "http://linked.data.gov.au/def/asgs#GreaterCapitalCityStatisticalArea",
+            "http://linked.data.gov.au/def/asgs#SignificantUrbanArea",
+            "http://linked.data.gov.au/def/asgs#RemotenessArea",
+            "http://linked.data.gov.au/def/asgs#IndigenousLocation",
+            "http://linked.data.gov.au/def/asgs#IndigenousArea",
+            "http://linked.data.gov.au/def/asgs#IndigenousRegion",
+            "http://linked.data.gov.au/def/asgs#UrbanCentreAndLocality",
+            "http://linked.data.gov.au/def/asgs#SectionOfStateRange",
+            "http://linked.data.gov.au/def/asgs#SectionOfState",
+            "http://linked.data.gov.au/def/asgs#LocalGovernmentArea",
+            "http://linked.data.gov.au/def/asgs#CommonwealthElectoralDivision",
+            "http://linked.data.gov.au/def/asgs#StateSuburb",
+            "http://linked.data.gov.au/def/asgs#NaturalResourceManagementRegion"
         ],
         "baseType": true
     },
@@ -22,7 +35,20 @@
             "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel2",
             "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3",
             "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4",
-            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory",
+            "http://linked.data.gov.au/def/asgs#GreaterCapitalCityStatisticalArea",
+            "http://linked.data.gov.au/def/asgs#SignificantUrbanArea",
+            "http://linked.data.gov.au/def/asgs#RemotenessArea",
+            "http://linked.data.gov.au/def/asgs#IndigenousLocation",
+            "http://linked.data.gov.au/def/asgs#IndigenousArea",
+            "http://linked.data.gov.au/def/asgs#IndigenousRegion",
+            "http://linked.data.gov.au/def/asgs#UrbanCentreAndLocality",
+            "http://linked.data.gov.au/def/asgs#SectionOfStateRange",
+            "http://linked.data.gov.au/def/asgs#SectionOfState",
+            "http://linked.data.gov.au/def/asgs#LocalGovernmentArea",
+            "http://linked.data.gov.au/def/asgs#CommonwealthElectoralDivision",
+            "http://linked.data.gov.au/def/asgs#StateSuburb",
+            "http://linked.data.gov.au/def/asgs#NaturalResourceManagementRegion"
         ]
     },
     {
@@ -33,7 +59,9 @@
         "withinTypes": [
             "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3",
             "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4",
-            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory",
+            "http://linked.data.gov.au/def/asgs#GreaterCapitalCityStatisticalArea",
+            "http://linked.data.gov.au/def/asgs#SignificantUrbanArea"
         ]
     },
     {
@@ -61,6 +89,93 @@
         "uri": "http://linked.data.gov.au/def/asgs#StateOrTerritory",
         "prefix": "http://linked.data.gov.au/dataset/asgs2016/stateorterritory/"
     },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2016",
+        "title": "Greater Capital City Statistical Area",
+        "uri": "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2016/greatercapitalcitystatisticalarea/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2016",
+        "title": "Significant Urban Area",
+        "uri": "http://linked.data.gov.au/def/asgs#SignificantUrbanArea",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2016/significanturbanarea/",
+        "withinTypes": [
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2016",
+        "title": "Remoteness Area",
+        "uri": "http://linked.data.gov.au/def/asgs#RemotenessArea",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2016/remotenessarea/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2016",
+        "title": "Indigenous Location",
+        "uri": "http://linked.data.gov.au/def/asgs#IndigenousLocation",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2016/indigenouslocation/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory",
+            "http://linked.data.gov.au/def/asgs#IndigenousArea",
+            "http://linked.data.gov.au/def/asgs#IndigenousRegion"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2016",
+        "title": "Indigenous Area",
+        "uri": "http://linked.data.gov.au/def/asgs#IndigenousArea",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2016/indigenousarea/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory",
+            "http://linked.data.gov.au/def/asgs#IndigenousRegion"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2016",
+        "title": "Indigenous Region",
+        "uri": "http://linked.data.gov.au/def/asgs#IndigenousRegion",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2016/indigenousregion/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2016",
+        "title": "Urban Centre and Locality",
+        "uri": "http://linked.data.gov.au/def/asgs#UrbanCentreAndLocality",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2016/urbancentreandlocality",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory",
+            "http://linked.data.gov.au/def/asgs#SectionOfStateRange",
+            "http://linked.data.gov.au/def/asgs#SectionOfState"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2016",
+        "title": "Section of State Range",
+        "uri": "http://linked.data.gov.au/def/asgs#SectionOfStateRange",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2016/sectionofstaterange/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory",
+            "http://linked.data.gov.au/def/asgs#SectionOfState"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2016",
+        "title": "Section of State",
+        "uri": "http://linked.data.gov.au/def/asgs#SectionOfState",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2016/sectionofstate/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
+        ]
+    },
+
     {
         "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
         "title": "MeshBlock",
@@ -123,6 +238,93 @@
         "uri": "http://linked.data.gov.au/def/asgs#StateOrTerritory",
         "prefix": "http://linked.data.gov.au/dataset/asgs2011/stateorterritory/"
     },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
+        "title": "Greater Capital City Statistical Area",
+        "uri": "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2011/greatercapitalcitystatisticalarea/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
+        "title": "Significant Urban Area",
+        "uri": "http://linked.data.gov.au/def/asgs#SignificantUrbanArea",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2011/significanturbanarea/",
+        "withinTypes": [
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
+        "title": "Remoteness Area",
+        "uri": "http://linked.data.gov.au/def/asgs#RemotenessArea",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2011/remotenessarea/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
+        "title": "Indigenous Location",
+        "uri": "http://linked.data.gov.au/def/asgs#IndigenousLocation",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2011/indigenouslocation/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory",
+            "http://linked.data.gov.au/def/asgs#IndigenousArea",
+            "http://linked.data.gov.au/def/asgs#IndigenousRegion"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
+        "title": "Indigenous Area",
+        "uri": "http://linked.data.gov.au/def/asgs#IndigenousArea",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2011/indigenousarea/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory",
+            "http://linked.data.gov.au/def/asgs#IndigenousRegion"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
+        "title": "Indigenous Region",
+        "uri": "http://linked.data.gov.au/def/asgs#IndigenousRegion",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2011/indigenousregion/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
+        "title": "Urban Centre and Locality",
+        "uri": "http://linked.data.gov.au/def/asgs#UrbanCentreAndLocality",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2011/urbancentreandlocality",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory",
+            "http://linked.data.gov.au/def/asgs#SectionOfStateRange",
+            "http://linked.data.gov.au/def/asgs#SectionOfState"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
+        "title": "Section of State Range",
+        "uri": "http://linked.data.gov.au/def/asgs#SectionOfStateRange",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2011/sectionofstaterange/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory",
+            "http://linked.data.gov.au/def/asgs#SectionOfState"
+        ]
+    },
+    {
+        "datasetUri": "http://linked.data.gov.au/dataset/asgs2011",
+        "title": "Section of State",
+        "uri": "http://linked.data.gov.au/def/asgs#SectionOfState",
+        "prefix": "http://linked.data.gov.au/dataset/asgs2011/sectionofstate/",
+        "withinTypes": [
+            "http://linked.data.gov.au/def/asgs#StateOrTerritory"
+        ]
+    },    
+    
     {
         "datasetUri": "http://linked.data.gov.au/dataset/geofabric",
         "title": "Contracted Catchment",


### PR DESCRIPTION
Create a JSON file with info that was previously captured in Excelerator on Loc-I Datatypes and base types, so this info can be used in other tools, APIs. See https://github.com/CSIRO-enviro-informatics/loci-excelerator/blob/master/excelerator/imports/api/methods-init.js#L148

See also 
CSIRO-enviro-informatics/asgs-dataset#12
https://www.abs.gov.au/websitedbs/D3310114.nsf/4a256353001af3ed4b2562bb00121564/c453c497aadde71cca2576d300026a38/Body/2.1E7E!OpenElement&FieldElemFormat=jpg